### PR TITLE
Bootstrap SLF4J while still in MC-BOOTSTRAP classloader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     implementation('org.apache.logging.log4j:log4j-api:2.14.1')
     implementation('org.apache.logging.log4j:log4j-core:2.14.1')
     implementation('cpw.mods:securejarhandler:0.9.+')
-    implementation('org.slf4j:slf4j-api:1.8.0-beta4')
     annotationProcessor('org.apache.logging.log4j:log4j-core:2.14.1')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.+')
     testImplementation('org.powermock:powermock-core:2.0.+')

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     implementation('org.apache.logging.log4j:log4j-api:2.14.1')
     implementation('org.apache.logging.log4j:log4j-core:2.14.1')
     implementation('cpw.mods:securejarhandler:0.9.+')
+    implementation('org.slf4j:slf4j-api:1.8.0-beta4')
     annotationProcessor('org.apache.logging.log4j:log4j-core:2.14.1')
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.7.+')
     testImplementation('org.powermock:powermock-core:2.0.+')
@@ -187,4 +188,8 @@ publishing {
             url 'https://maven.minecraftforge.net/releases/'
         }
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = "UTF-8"
 }

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -22,7 +22,6 @@ import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.modlauncher.api.*;
 import org.apache.logging.log4j.LogManager;
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -49,7 +48,7 @@ public class Launcher {
 
     private Launcher() {
         INSTANCE = this;
-        LoggerFactory.getILoggerFactory(); //This hack bootstraps SLF4J while we're still on MC-BOOTSTRAP, where the SLF4J Providers can be ServiceLoaded
+        try { Class.forName("org.slf4j.LoggerFactory").getMethod("getILoggerFactory").invoke(null); } catch (Exception ignored) {} //This hack bootstraps SLF4J while we're still on MC-BOOTSTRAP, where the SLF4J Providers can be ServiceLoaded
         LogManager.getLogger().info(MODLAUNCHER,"ModLauncher {} starting: java version {} by {}", ()->IEnvironment.class.getPackage().getImplementationVersion(),  () -> System.getProperty("java.version"), ()->System.getProperty("java.vendor"));
         this.moduleLayerHandler = new ModuleLayerHandler();
         this.launchService = new LaunchServiceHandler(this.moduleLayerHandler);

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -22,6 +22,7 @@ import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.modlauncher.api.*;
 import org.apache.logging.log4j.LogManager;
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.*;
@@ -48,6 +49,7 @@ public class Launcher {
 
     private Launcher() {
         INSTANCE = this;
+        LoggerFactory.getILoggerFactory(); //This hack bootstraps SLF4J while we're still on MC-BOOTSTRAP, where the SLF4J Providers can be ServiceLoaded
         LogManager.getLogger().info(MODLAUNCHER,"ModLauncher {} starting: java version {} by {}", ()->IEnvironment.class.getPackage().getImplementationVersion(),  () -> System.getProperty("java.version"), ()->System.getProperty("java.vendor"));
         this.moduleLayerHandler = new ModuleLayerHandler();
         this.launchService = new LaunchServiceHandler(this.moduleLayerHandler);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,7 +4,6 @@ module cpw.mods.modlauncher {
     requires org.objectweb.asm.tree;
     requires org.apache.logging.log4j.core;
     requires jopt.simple;
-    requires org.slf4j;
     requires cpw.mods.securejarhandler;
     requires static org.jetbrains.annotations;
     exports cpw.mods.modlauncher.log;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module cpw.mods.modlauncher {
     requires org.objectweb.asm.tree;
     requires org.apache.logging.log4j.core;
     requires jopt.simple;
+    requires org.slf4j;
     requires cpw.mods.securejarhandler;
     requires static org.jetbrains.annotations;
     exports cpw.mods.modlauncher.log;


### PR DESCRIPTION
This will allow SLF4J to find its Log4J bindings, stopping SLF4J from complaining and enabling logs for libraries that use SLF4J (netty in particular). Also includes a change to build.gradle to ensure compilation uses UTF-8 encoding.
[broken debug.log](https://github.com/cpw/modlauncher/files/7035991/broken.debug.log)
[fixed debug.log](https://github.com/cpw/modlauncher/files/7035992/fixed.debug.log)
