### PR TITLE
Set Environment Properties that are set by argument's earlier

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -82,7 +82,7 @@ public class Launcher {
     }
 
     private void run(String... args) {
-        final Path gameDir = this.argumentHandler.setArgs(args);
+        final Path gameDir = this.argumentHandler.setArgs(args, this.environment);
         this.transformationServicesHandler.discoverServices(gameDir);
         final var scanResults = this.transformationServicesHandler.initializeTransformationServices(this.argumentHandler, this.environment, this.nameMappingServiceHandler);
         var bylayer = scanResults.stream().collect(Collectors.groupingBy(ITransformationService.Resource::target));

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -66,7 +66,7 @@ class TransformationServicesHandler {
     private void processArguments(ArgumentHandler argumentHandler, Environment environment) {
         LOGGER.debug(MODLAUNCHER,"Configuring option handling for services");
 
-        argumentHandler.processArguments(environment, this::computeArgumentsForServices, this::offerArgumentResultsToServices);
+        argumentHandler.processArguments(this::computeArgumentsForServices, this::offerArgumentResultsToServices);
     }
 
     private void computeArgumentsForServices(OptionParser parser) {


### PR DESCRIPTION
Set's the environment properties that are set by command line argument's earlier so that they can be accessed by classes implementing `ITransformerDiscoveryService`.

Needed for https://github.com/MinecraftForge/MinecraftForge/pull/8118 so that `ClasspathTransformerDiscovery` can be enabled only in a dev environment.

I couldn't do any test's since they are disabled in the `build.gradle` which also say's that the test's don't work with modules but I do know that it atleast compiles.