### PR TITLE
Add an API for TransformationServicesHandler exposing the launch target

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
@@ -38,13 +38,16 @@ public class ArgumentHandler {
     private OptionSpec<String> launchTarget;
     private OptionSpec<String> uuidOption;
 
-    Path setArgs(String[] args) {
+    record DiscoveryData(Path gameDir, String launchTarget) {}
+
+    DiscoveryData setArgs(String[] args) {
         this.args = args;
         final OptionParser parser = new OptionParser();
-        final ArgumentAcceptingOptionSpec<Path> gameDir = parser.accepts("gameDir", "Alternative game directory").withRequiredArg().withValuesConvertedBy(new PathConverter(PathProperties.DIRECTORY_EXISTING)).defaultsTo(Path.of("."));
+        final var gameDir = parser.accepts("gameDir", "Alternative game directory").withRequiredArg().withValuesConvertedBy(new PathConverter(PathProperties.DIRECTORY_EXISTING)).defaultsTo(Path.of("."));
+        final var launchTarget = parser.accepts("launchTarget", "LauncherService target to launch").withRequiredArg();
         parser.allowsUnrecognizedOptions();
         final OptionSet optionSet = parser.parse(args);
-        return optionSet.valueOf(gameDir);
+        return new DiscoveryData(optionSet.valueOf(gameDir), optionSet.valueOf(launchTarget));
     }
 
     void processArguments(Environment env, Consumer<OptionParser> parserConsumer, BiConsumer<OptionSet, BiFunction<String, OptionSet, ITransformationService.OptionResult>> resultConsumer) {

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -82,8 +82,8 @@ public class Launcher {
     }
 
     private void run(String... args) {
-        final Path gameDir = this.argumentHandler.setArgs(args);
-        this.transformationServicesHandler.discoverServices(gameDir);
+        final ArgumentHandler.DiscoveryData discoveryData = this.argumentHandler.setArgs(args);
+        this.transformationServicesHandler.discoverServices(discoveryData);
         final var scanResults = this.transformationServicesHandler.initializeTransformationServices(this.argumentHandler, this.environment, this.nameMappingServiceHandler);
         var bylayer = scanResults.stream().collect(Collectors.groupingBy(ITransformationService.Resource::target));
         bylayer.getOrDefault(IModuleLayerManager.Layer.PLUGIN, List.of())

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.Logger;
 
 
 import java.net.URL;
-import java.nio.file.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
@@ -117,11 +116,11 @@ class TransformationServicesHandler {
         serviceLookup.values().forEach(s -> s.onLoad(environment, serviceLookup.keySet()));
     }
 
-    void discoverServices(final Path gameDir) {
+    void discoverServices(final ArgumentHandler.DiscoveryData discoveryData) {
         LOGGER.debug(MODLAUNCHER, "Discovering transformation services");
         var bootLayer = layerHandler.getLayer(IModuleLayerManager.Layer.BOOT).orElseThrow();
         var additionalPaths = ServiceLoaderUtils.streamServiceLoader(()->ServiceLoader.load(bootLayer, ITransformerDiscoveryService.class),  sce -> LOGGER.fatal(MODLAUNCHER, "Encountered serious error loading transformation discoverer, expect problems", sce))
-                .map(s->s.candidates(gameDir))
+                .map(s->s.candidates(discoveryData.gameDir(), discoveryData.launchTarget()))
                 .<NamedPath>mapMulti(Iterable::forEach)
                 .toList();
         LOGGER.debug(MODLAUNCHER, "Found additional transformation services from discovery services: {}", ()->additionalPaths.stream().map(ap->Arrays.toString(ap.paths())));

--- a/src/main/java/cpw/mods/modlauncher/serviceapi/ITransformerDiscoveryService.java
+++ b/src/main/java/cpw/mods/modlauncher/serviceapi/ITransformerDiscoveryService.java
@@ -34,4 +34,17 @@ public interface ITransformerDiscoveryService {
      * @return The list of services
      */
     List<NamedPath> candidates(final Path gameDirectory);
+
+    /**
+     * Return a list of additional paths to be added to transformer service discovery during loading.
+     *
+     * Defaults to calling {@link #candidates(Path)}
+     *
+     * @param gameDirectory The root game directory
+     * @param launchTarget The launch target
+     * @return The list of services
+     */
+    default List<NamedPath> candidates(final Path gameDirectory, final String launchTarget) {
+        return candidates(gameDirectory);
+    }
 }


### PR DESCRIPTION
This is my proposal for solving the TransformationServices issue, rather than completely break the existing behaviours..