### PR TITLE
Update ASM API version to support J17 features

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -68,7 +68,7 @@ public class ClassTransformer {
             return inputClass;
         }
 
-        ClassNode clazz = new ClassNode(Opcodes.ASM7);
+        ClassNode clazz = new ClassNode(Opcodes.ASM9);
         Supplier<byte[]> digest;
         boolean empty;
         if (inputClass.length > 0) {

--- a/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
+++ b/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
@@ -25,23 +25,25 @@ import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
 public class PredicateVisitor extends ClassVisitor {
+    private static final int ASM_API = Opcodes.ASM9;
+    
     private ITransformerVotingContext.MethodPredicate methodPredicate;
     private ITransformerVotingContext.FieldPredicate fieldPredicate;
     private ITransformerVotingContext.ClassPredicate classPredicate;
     private boolean result;
 
     PredicateVisitor(final ITransformerVotingContext.FieldPredicate fieldPredicate) {
-        super(Opcodes.ASM7);
+        super(ASM_API);
         this.fieldPredicate = fieldPredicate;
     }
 
     PredicateVisitor(final ITransformerVotingContext.MethodPredicate methodPredicate) {
-        super(Opcodes.ASM7);
+        super(ASM_API);
         this.methodPredicate = methodPredicate;
     }
 
     PredicateVisitor(final ITransformerVotingContext.ClassPredicate classPredicate) {
-        super(Opcodes.ASM7);
+        super(ASM_API);
         this.classPredicate = classPredicate;
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -166,7 +166,7 @@ class TransformerClassWriter extends ClassWriter {
     private class SuperCollectingVisitor extends ClassVisitor {
 
         public SuperCollectingVisitor() {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM9);
         }
 
         @Override


### PR DESCRIPTION
The new ASM API changes do not impact our current uses, so this is a straightforward version bump.

From an analysis of these uses posted in the `#mcmodlauncher` discord channel:

- `ClassTransformer`: just creating a ClassNode, seems like if ClassNode correctly overrides every visit method, the api version constant is never checked
- `PredicateVisitor`: changes to visit/visitField/visitMethod, none of which have changed behavior between 7 and 9
- `TransformerClassWriter$SuperCollectingVisitor`: any changes in inheritance behavior. sealed classes and records both have specific inheritance constraints, but none affect the information collected from this visitor

Fixes #74