### PR TITLE
[8.1] Exclude all main branches from secondary builds

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -79,6 +79,7 @@ object BuildSecondaryBranches : BuildType({
         branchFilter = """
             +:*
             -:<default>
+            -:main*
         """.trimIndent()
     }
 })


### PR DESCRIPTION
This excludes the 8.1 branch from building as a secondary branch.