### PR TITLE
Fix OpenJ9 detection

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -65,12 +65,12 @@ public class Launcher {
     }
 
     public static void main(String... args) {
-        if (System.getProperty("java.vendor").contains("OpenJ9")) {
+        if (System.getProperty("java.vm.name").contains("OpenJ9")) {
             System.err.printf("""
             You are attempting to run with an unsupported Java Virtual Machine : %s
             Please visit https://adoptopenjdk.net and install the HotSpot variant.
             OpenJ9 is incompatible with several of the transformation behaviours that we rely on to work.
-            """, System.getProperty("java.vendor"));
+            """, System.getProperty("java.vm.name"));
             throw new IllegalStateException("Open J9 is not supported");
         }
         LogManager.getLogger().info(MODLAUNCHER,"ModLauncher running: args {}", () -> LaunchServiceHandler.hideAccessToken(args));


### PR DESCRIPTION
As explained in #67, modlauncher fails to detect certain OpenJ9 builds, specifically those from AdoptOpenJDK.
This PR changes the checked property from `java.vendor` to `java.vm.name`, which contains the expected identifier `OpenJ9`.

I've tested this on IBM Semeru 16.0.2.0, which is the only available distribution I could find for the current target version (java 16). It had the `java.vm.name` property set to `Eclipse OpenJ9 VM`, and modlauncher detected it successfully.