### PR TITLE
Add MLClassLoaderContextSelector to avoid multiple log4j2 contexts in one application

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/log/MLClassLoaderContextSelector.java
+++ b/src/main/java/cpw/mods/modlauncher/log/MLClassLoaderContextSelector.java
@@ -1,0 +1,19 @@
+package cpw.mods.modlauncher.log;
+
+import cpw.mods.cl.ModuleClassLoader;
+import org.apache.logging.log4j.core.selector.ClassLoaderContextSelector;
+
+/**
+ * A custom context selector to avoid initializing multiple log4j contexts due to {@link ModuleClassLoader#getParent()} always returning null (as a {@link ModuleClassLoader} can have multiple parents).
+ * As all {@link ModuleClassLoader}s should get the same log4j context, we just return a static string with "MCL", otherwise we use the default logic
+ */
+public class MLClassLoaderContextSelector extends ClassLoaderContextSelector {
+
+    @Override
+    protected String toContextMapKey(ClassLoader loader) {
+        if (loader instanceof ModuleClassLoader) {
+            return "MCL";
+        }
+        return super.toContextMapKey(loader);
+    }
+}

--- a/src/main/resources/log4j2.component.properties
+++ b/src/main/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+Log4jContextSelector=cpw.mods.modlauncher.log.MLClassLoaderContextSelector


### PR DESCRIPTION
Forge currently has a problem where one instance of minecraft has multiple log4j2 contexts, which have different log configuration, which results in some loggers using the forge log4j xml and some the vanilla / modlaunchers log4j.xml
This can lead to weird situations where the output of one message has a different pattern than the next one, and even causes some messages to not appear at all in the debug.log, as this file only exists in the forge log4j2.xml

This is caused due to the different module class loaders used for different classes, which in turn causes the ClassLoaderContextSelector that log4j uses to determine the log configuration to think that they are two totally seperate configurations. Normally, log4j would try to find a common parent and use that context, but as all ModuleClassLoaders have a null parent that doesn't work either.

Fortunally, log4j allows to swap the Context Selector.
This PR adds a custom Context Selector and a configuration that sets that selector so all ModuleClassLoaders get the same context.
This may not be the most beautiful solution, but it seemed like the only way to get this working without major changes to the design of securejarhandler/modlauncher.

Before (Dev-Environment):
![idea64_hIzVnUUvtK](https://user-images.githubusercontent.com/20151702/156002071-d63f6afd-a7ee-41ee-9e23-3b1bf60ddec0.png)
After (Dev-Environment):
![idea64_8M649CJ4cn](https://user-images.githubusercontent.com/20151702/156002110-9702ce2c-4677-4070-a429-887ff9051357.png)

