### PR TITLE
Safe Transformer Types

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -94,7 +94,7 @@ public class ClassTransformer {
         if (needsTransforming) {
             VotingContext context = new VotingContext(className, empty, digest, auditTrail.getActivityFor(className), reason);
 
-            List<ITransformer<ClassNode>> preClassTransformers = new ArrayList<>(transformers.getTransformersFor(className, TransformTargetLabel.LabelType.PRE_CLASS));
+            List<ITransformer<ClassNode>> preClassTransformers = new ArrayList<>(transformers.getTransformersFor(className, TargetType.PRE_CLASS));
             clazz = this.performVote(preClassTransformers, clazz, context);
 
             List<FieldNode> fieldList = new ArrayList<>(clazz.fields.size());
@@ -113,7 +113,7 @@ public class ClassTransformer {
 
             clazz.fields = fieldList;
             clazz.methods = methodList;
-            List<ITransformer<ClassNode>> classTransformers = new ArrayList<>(transformers.getTransformersFor(className, TransformTargetLabel.LabelType.CLASS));
+            List<ITransformer<ClassNode>> classTransformers = new ArrayList<>(transformers.getTransformersFor(className, TargetType.CLASS));
             clazz = this.performVote(classTransformers, clazz, context);
         }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformStore.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformStore.java
@@ -33,29 +33,29 @@ import static cpw.mods.modlauncher.LogMarkers.*;
 public class TransformStore {
     private static final Logger LOGGER = LogManager.getLogger();
     private final Set<String> classNeedsTransforming = new HashSet<>();
-    private final EnumMap<TransformTargetLabel.LabelType, TransformList<?>> transformers;
+    private final Map<TargetType<?>, TransformList<?>> transformers;
 
     public TransformStore() {
-        transformers = new EnumMap<>(TransformTargetLabel.LabelType.class);
-        for (TransformTargetLabel.LabelType type : TransformTargetLabel.LabelType.values())
+        transformers = new HashMap<>();
+        for (TargetType<?> type : TargetType.VALUES)
             transformers.put(type, new TransformList<>(type.getNodeType()));
     }
 
     List<ITransformer<FieldNode>> getTransformersFor(String className, FieldNode field) {
         TransformTargetLabel tl = new TransformTargetLabel(className, field.name);
-        TransformList<FieldNode> transformerlist = TransformTargetLabel.LabelType.FIELD.getFromMap(this.transformers);
+        TransformList<FieldNode> transformerlist = TargetType.FIELD.get(this.transformers);
         return transformerlist.getTransformersForLabel(tl);
     }
 
     List<ITransformer<MethodNode>> getTransformersFor(String className, MethodNode method) {
         TransformTargetLabel tl = new TransformTargetLabel(className, method.name, method.desc);
-        TransformList<MethodNode> transformerlist = TransformTargetLabel.LabelType.METHOD.getFromMap(this.transformers);
+        TransformList<MethodNode> transformerlist = TargetType.METHOD.get(this.transformers);
         return transformerlist.getTransformersForLabel(tl);
     }
 
-    List<ITransformer<ClassNode>> getTransformersFor(String className, TransformTargetLabel.LabelType classType) {
+    List<ITransformer<ClassNode>> getTransformersFor(String className, TargetType<ClassNode> classType) {
         TransformTargetLabel tl = new TransformTargetLabel(className, classType);
-        TransformList<ClassNode> transformerlist = classType.getFromMap(this.transformers);
+        TransformList<ClassNode> transformerlist = classType.get(this.transformers);
         return transformerlist.getTransformersForLabel(tl);
     }
 
@@ -63,7 +63,7 @@ public class TransformStore {
     <T> void addTransformer(TransformTargetLabel targetLabel, ITransformer<T> transformer, ITransformationService service) {
         LOGGER.debug(MODLAUNCHER,"Adding transformer {} to {}", () -> transformer, () -> targetLabel);
         classNeedsTransforming.add(targetLabel.getClassName().getInternalName());
-        final TransformList<T> transformList = (TransformList<T>) this.transformers.get(targetLabel.getLabelType());
+        final TransformList<T> transformList = (TransformList<T>) this.transformers.get(targetLabel.getTargetType());
         transformList.addTransformer(targetLabel, new TransformerHolder<>(transformer, service));
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
@@ -69,12 +69,12 @@ public class TransformationServiceDecorator {
 
     public void gatherTransformers(TransformStore transformStore) {
         LOGGER.debug(MODLAUNCHER,"Initializing transformers for transformation service {}", this.service::name);
-        final List<ITransformer> transformers = this.service.transformers();
+        final List<? extends ITransformer<?>> transformers = this.service.transformers();
         Objects.requireNonNull(transformers, "The transformers list should not be null");
         transformers.forEach(xform -> {
             final TargetType<?> targetType = xform.getTargetType();
             Objects.requireNonNull(targetType, "Transformer type must not be null");
-            final Set<ITransformer.Target<?>> targets = xform.targets();
+            final Set<? extends ITransformer.Target<?>> targets = xform.targets();
             if (!targets.isEmpty()) {
                 final Map<TargetType<?>, List<TransformTargetLabel>> targetTypeListMap = targets.stream()
                     .map(TransformTargetLabel::new)

--- a/src/main/java/cpw/mods/modlauncher/TransformerHolder.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerHolder.java
@@ -18,10 +18,7 @@
 
 package cpw.mods.modlauncher;
 
-import cpw.mods.modlauncher.api.ITransformationService;
-import cpw.mods.modlauncher.api.ITransformer;
-import cpw.mods.modlauncher.api.ITransformerVotingContext;
-import cpw.mods.modlauncher.api.TransformerVoteResult;
+import cpw.mods.modlauncher.api.*;
 
 import org.jetbrains.annotations.NotNull;
 import java.util.Set;
@@ -49,8 +46,13 @@ public class TransformerHolder<T> implements ITransformer<T> {
 
     @NotNull
     @Override
-    public Set<Target> targets() {
+    public Set<Target<T>> targets() {
         return wrapped.targets();
+    }
+
+    @Override
+    public TargetType<T> getTargetType() {
+        return wrapped.getTargetType();
     }
 
     @Override

--- a/src/main/java/cpw/mods/modlauncher/api/ITransformationService.java
+++ b/src/main/java/cpw/mods/modlauncher/api/ITransformationService.java
@@ -23,7 +23,6 @@ import joptsimple.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URL;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.function.*;
 
@@ -97,7 +96,7 @@ public interface ITransformationService {
      * you find yourself in.
      */
     @NotNull
-    List<ITransformer> transformers();
+    List<? extends ITransformer<?>> transformers();
 
     /**
      * Allow transformation services to provide additional classes when asked for.

--- a/src/main/java/cpw/mods/modlauncher/api/TargetType.java
+++ b/src/main/java/cpw/mods/modlauncher/api/TargetType.java
@@ -1,0 +1,65 @@
+package cpw.mods.modlauncher.api;
+
+import cpw.mods.modlauncher.TransformList;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Specifies the target type for the {@link ITransformer.Target}. Note that the type of the transformer T
+ * dictates what are acceptable targets for this transformer.
+ */
+public final class TargetType<T> {
+    /**
+     * Target a class, before field and method transforms operate. SHOULD ONLY BE USED to "replace" a complete class
+     * The {@link ITransformer} T variable must refer to {@link org.objectweb.asm.tree.ClassNode}
+     */
+    public static final TargetType<ClassNode> PRE_CLASS = new TargetType<>("PRE_CLASS", ClassNode.class);
+    /**
+     * Target a class. The {@link ITransformer} T variable must refer to {@link org.objectweb.asm.tree.ClassNode}
+     */
+    public static final TargetType<ClassNode> CLASS = new TargetType<>("CLASS", ClassNode.class);
+    /**
+     * Target a method. The {@link ITransformer} T variable must refer to {@link org.objectweb.asm.tree.MethodNode}
+     */
+    public static final TargetType<MethodNode> METHOD = new TargetType<>("METHOD", MethodNode.class);
+    /**
+     * Target a field. The {@link ITransformer} T variable must refer to {@link org.objectweb.asm.tree.FieldNode}
+     */
+    public static final TargetType<FieldNode> FIELD = new TargetType<>("FIELD", FieldNode.class);
+    
+    public static final TargetType<?>[] VALUES = new TargetType<?>[] { PRE_CLASS, CLASS, METHOD, FIELD };
+
+    private final String name;
+    private final Class<T> nodeType;
+
+    private TargetType(String name, Class<T> nodeType) {
+        this.name = name;
+        this.nodeType = nodeType;
+    }
+
+    public Class<T> getNodeType() {
+        return this.nodeType;
+    }
+    
+    public static TargetType<?> byName(String name) {
+        return Stream.of(VALUES)
+            .filter(type -> type.name.equals(name))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("No TargetType of name " + name + " found"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public TransformList<T> get(Map<TargetType<?>, TransformList<?>> transformers) {
+        return (TransformList<T>) transformers.get(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Supplier<TransformList<T>> mapSupplier(Map<TargetType<?>, TransformList<?>> transformers) {
+        return () -> (TransformList<T>) transformers.get(this);
+    }
+}

--- a/src/test/java/cpw/mods/modlauncher/test/ClassTransformerTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/ClassTransformerTests.java
@@ -106,8 +106,13 @@ class ClassTransformerTests {
 
             @NotNull
             @Override
-            public Set<Target> targets() {
+            public Set<Target<FieldNode>> targets() {
                 return Collections.emptySet();
+            }
+
+            @Override
+            public TargetType<FieldNode> getTargetType() {
+                return TargetType.FIELD;
             }
         };
     }
@@ -131,8 +136,13 @@ class ClassTransformerTests {
 
             @NotNull
             @Override
-            public Set<Target> targets() {
+            public Set<Target<ClassNode>> targets() {
                 return Collections.emptySet();
+            }
+
+            @Override
+            public TargetType<ClassNode> getTargetType() {
+                return TargetType.CLASS;
             }
         };
     }

--- a/src/test/java/cpw/mods/modlauncher/test/ClassTransformerTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/ClassTransformerTests.java
@@ -22,6 +22,7 @@ import cpw.mods.modlauncher.*;
 import cpw.mods.modlauncher.api.ITransformationService;
 import cpw.mods.modlauncher.api.ITransformer;
 import cpw.mods.modlauncher.api.ITransformerVotingContext;
+import cpw.mods.modlauncher.api.TargetType;
 import cpw.mods.modlauncher.api.TransformerVoteResult;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
@@ -53,7 +54,7 @@ class ClassTransformerTests {
         final LaunchPluginHandler lph = new LaunchPluginHandler(layerHandler);
         final ClassTransformer classTransformer = Whitebox.invokeConstructor(ClassTransformer.class, new Class[] { transformStore.getClass(),  lph.getClass(), TransformingClassLoader.class }, new Object[] { transformStore, lph, null});
         final ITransformationService dummyService = new MockTransformerService();
-        Whitebox.invokeMethod(transformStore, "addTransformer", new TransformTargetLabel("test.MyClass", TransformTargetLabel.LabelType.CLASS), classTransformer(), dummyService);
+        Whitebox.invokeMethod(transformStore, "addTransformer", new TransformTargetLabel("test.MyClass", TargetType.CLASS), classTransformer(), dummyService);
         byte[] result = Whitebox.invokeMethod(classTransformer, "transform", new Class[]{byte[].class, String.class,String.class}, new byte[0], "test.MyClass","testing");
         assertAll("Class loads and is valid",
                 () -> assertNotNull(result),

--- a/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
+++ b/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
@@ -18,7 +18,6 @@
 
 package cpw.mods.modlauncher.test;
 
-import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.modlauncher.api.*;
 import joptsimple.*;
 import org.jetbrains.annotations.NotNull;
@@ -94,7 +93,7 @@ public class MockTransformerService implements ITransformationService {
 
     @NotNull
     @Override
-    public List<ITransformer> transformers() {
+    public List<? extends ITransformer<?>> transformers() {
         return Stream.of(new ClassNodeTransformer(modList)).collect(Collectors.toList());
     }
 

--- a/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
+++ b/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
@@ -18,6 +18,7 @@
 
 package cpw.mods.modlauncher.test;
 
+import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.modlauncher.api.*;
 import joptsimple.*;
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
+++ b/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
@@ -121,8 +121,13 @@ public class MockTransformerService implements ITransformationService {
 
         @NotNull
         @Override
-        public Set<Target> targets() {
+        public Set<Target<ClassNode>> targets() {
             return classNames.stream().map(Target::targetClass).collect(Collectors.toSet());
+        }
+
+        @Override
+        public TargetType<ClassNode> getTargetType() {
+            return TargetType.CLASS;
         }
     }
 

--- a/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
@@ -55,14 +55,14 @@ class TransformationServiceDecoratorTests {
 
         TransformationServiceDecorator sd = Whitebox.invokeConstructor(TransformationServiceDecorator.class, mockTransformerService);
         sd.gatherTransformers(store);
-        EnumMap<TransformTargetLabel.LabelType, TransformList<?>> transformers = Whitebox.getInternalState(store, "transformers");
+        Map<TargetType<?>, TransformList<?>> transformers = Whitebox.getInternalState(store, "transformers");
         Set<String> targettedClasses = Whitebox.getInternalState(store, "classNeedsTransforming");
         assertAll(
-                () -> assertTrue(transformers.containsKey(TransformTargetLabel.LabelType.CLASS), "transformers contains class"),
-                () -> assertTrue(getTransformers(transformers.get(TransformTargetLabel.LabelType.CLASS)).values().stream().flatMap(Collection::stream).allMatch(s -> Whitebox.getInternalState(s,"wrapped") == classNodeTransformer), "transformers contains classTransformer"),
+                () -> assertTrue(transformers.containsKey(TargetType.CLASS), "transformers contains class"),
+                () -> assertTrue(getTransformers(transformers.get(TargetType.CLASS)).values().stream().flatMap(Collection::stream).allMatch(s -> Whitebox.getInternalState(s,"wrapped") == classNodeTransformer), "transformers contains classTransformer"),
                 () -> assertTrue(targettedClasses.contains("cheese/Puffs"), "targetted classes contains class name cheese/Puffs"),
-                () -> assertTrue(transformers.containsKey(TransformTargetLabel.LabelType.METHOD), "transformers contains method"),
-                () -> assertTrue(getTransformers(transformers.get(TransformTargetLabel.LabelType.METHOD)).values().stream().flatMap(Collection::stream).allMatch(s -> Whitebox.getInternalState(s,"wrapped") == methodNodeTransformer), "transformers contains methodTransformer"),
+                () -> assertTrue(transformers.containsKey(TargetType.METHOD), "transformers contains method"),
+                () -> assertTrue(getTransformers(transformers.get(TargetType.METHOD)).values().stream().flatMap(Collection::stream).allMatch(s -> Whitebox.getInternalState(s,"wrapped") == methodNodeTransformer), "transformers contains methodTransformer"),
                 () -> assertTrue(targettedClasses.contains("cheesy/PuffMethod"), "targetted classes contains class name cheesy/PuffMethod")
         );
     }
@@ -89,8 +89,13 @@ class TransformationServiceDecoratorTests {
 
         @NotNull
         @Override
-        public Set<Target> targets() {
+        public Set<Target<ClassNode>> targets() {
             return Stream.of(Target.targetClass("cheese.Puffs")).collect(Collectors.toSet());
+        }
+
+        @Override
+        public TargetType<ClassNode> getTargetType() {
+            return TargetType.CLASS;
         }
     }
 
@@ -109,8 +114,13 @@ class TransformationServiceDecoratorTests {
 
         @NotNull
         @Override
-        public Set<Target> targets() {
+        public Set<Target<MethodNode>> targets() {
             return Stream.of(Target.targetMethod("cheesy.PuffMethod", "fish", "()V")).collect(Collectors.toSet());
+        }
+
+        @Override
+        public TargetType<MethodNode> getTargetType() {
+            return TargetType.METHOD;
         }
     }
 }

--- a/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
@@ -47,7 +47,7 @@ class TransformationServiceDecoratorTests {
         MockTransformerService mockTransformerService = new MockTransformerService() {
             @NotNull
             @Override
-            public List<ITransformer> transformers() {
+            public List<? extends ITransformer<?>> transformers() {
                 return Stream.of(classNodeTransformer, methodNodeTransformer).collect(Collectors.toList());
             }
         };

--- a/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformationServiceDecoratorTests.java
@@ -24,6 +24,7 @@ import cpw.mods.modlauncher.TransformTargetLabel;
 import cpw.mods.modlauncher.TransformationServiceDecorator;
 import cpw.mods.modlauncher.api.ITransformer;
 import cpw.mods.modlauncher.api.ITransformerVotingContext;
+import cpw.mods.modlauncher.api.TargetType;
 import cpw.mods.modlauncher.api.TransformerVoteResult;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
@@ -50,7 +50,7 @@ class TransformingClassLoaderTests {
         MockTransformerService mockTransformerService = new MockTransformerService() {
             @NotNull
             @Override
-            public List<ITransformer> transformers() {
+            public List<ITransformer<?>> transformers() {
                 return Stream.of(new ClassNodeTransformer(List.of(TARGET_CLASS))).collect(Collectors.toList());
             }
         };

--- a/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
@@ -50,7 +50,7 @@ class TransformingClassLoaderTests {
         MockTransformerService mockTransformerService = new MockTransformerService() {
             @NotNull
             @Override
-            public List<ITransformer<?>> transformers() {
+            public List<? extends ITransformer<?>> transformers() {
                 return Stream.of(new ClassNodeTransformer(List.of(TARGET_CLASS))).collect(Collectors.toList());
             }
         };


### PR DESCRIPTION
### The issue
Currently, modlauncher [determines](https://github.com/McModLauncher/modlauncher/blob/9b69c82a176c0896b264ab167813a52adc6f12cb/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java#L78-L84) the type of `ITransformer`s at runtime by getting their generic `T` type. However, this fails when the interface is implemented in a parent class.

See also:
- #97
- [Coremods](https://github.com/MinecraftForge/CoreMods/tree/master/src/main/java/net/minecraftforge/coremod/transformer) transformer class hierarchy

### Trouble with generics
To address the generics issue, we'll use _even more generics_.
We can't use bounded types because ASM Nodes don't share a common parent, and enums aren't an option either since they can't have generic parameters.

### The solution

So, we'll introduce a [transformer type class](src/main/java/cpw/mods/modlauncher/api/TargetType.java) whose generic `T` type must correspond to the transformer's `T` type. And by making it a "fake enum" with predefined instances we can effectively limit `ITransformer` to those types.
This type is then returned from the transformer in a new [`getTargetType`](https://github.com/Su5eD/modlauncher/blob/6c73b731c8c807ae667981f1362b24178a224d49/src/main/java/cpw/mods/modlauncher/api/ITransformer.java#L86) method.

Important disclaimer:  **This PR introduces BREAKING changes**