### PR TITLE
Rename LamdbaExceptionUtils to LambdaExceptionUtils

### DIFF
--- a/src/jmh/java/cpw/mods/modlauncher/benchmarks/TransformBenchmark.java
+++ b/src/jmh/java/cpw/mods/modlauncher/benchmarks/TransformBenchmark.java
@@ -38,7 +38,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
-import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.uncheck;
+import static cpw.mods.modlauncher.api.LambdaExceptionUtils.uncheck;
 
 @State(Scope.Benchmark)
 public class TransformBenchmark {

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
@@ -27,7 +27,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.jar.Manifest;
 
-import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.rethrowFunction;
+import static cpw.mods.modlauncher.api.LambdaExceptionUtils.rethrowFunction;
 
 class TransformingClassLoaderBuilder implements ITransformingClassLoaderBuilder {
     private final List<Path> transformationPaths = new ArrayList<>();

--- a/src/main/java/cpw/mods/modlauncher/api/LambdaExceptionUtils.java
+++ b/src/main/java/cpw/mods/modlauncher/api/LambdaExceptionUtils.java
@@ -22,83 +22,121 @@ import java.util.function.*;
 
 /**
  * From stackoverflow: https://stackoverflow.com/a/27644392
- * @deprecated Use {@link LambdaExceptionUtils}
  */
-@Deprecated(forRemoval = true)
-public class LamdbaExceptionUtils {
+public class LambdaExceptionUtils {
 
     /**
      * .forEach(rethrowConsumer(name -> System.out.println(Class.forName(name)))); or .forEach(rethrowConsumer(ClassNameUtil::println));
      */
     public static <T, E extends Exception> Consumer<T> rethrowConsumer(Consumer_WithExceptions<T, E> consumer) {
-        return LambdaExceptionUtils.rethrowConsumer(consumer::accept);
+        return t -> {
+            try {
+                consumer.accept(t);
+            } catch (Exception exception) {
+                throwAsUnchecked(exception);
+            }
+        };
     }
 
     public static <T, U, E extends Exception> BiConsumer<T, U> rethrowBiConsumer(BiConsumer_WithExceptions<T, U, E> biConsumer) {
-        return LambdaExceptionUtils.rethrowBiConsumer(biConsumer::accept);
+        return (t, u) -> {
+            try {
+                biConsumer.accept(t, u);
+            } catch (Exception exception) {
+                throwAsUnchecked(exception);
+            }
+        };
     }
 
     /**
      * .map(rethrowFunction(name -> Class.forName(name))) or .map(rethrowFunction(Class::forName))
      */
     public static <T, R, E extends Exception> Function<T, R> rethrowFunction(Function_WithExceptions<T, R, E> function) {
-        return LambdaExceptionUtils.rethrowFunction(function::apply);
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception exception) {
+                throwAsUnchecked(exception);
+                return null;
+            }
+        };
     }
 
     /**
      * rethrowSupplier(() -> new StringJoiner(new String(new byte[]{77, 97, 114, 107}, "UTF-8"))),
      */
     public static <T, E extends Exception> Supplier<T> rethrowSupplier(Supplier_WithExceptions<T, E> function) {
-        return LambdaExceptionUtils.rethrowSupplier(function::get);
+        return () -> {
+            try {
+                return function.get();
+            } catch (Exception exception) {
+                throwAsUnchecked(exception);
+                return null;
+            }
+        };
     }
 
     /**
      * uncheck(() -> Class.forName("xxx"));
      */
     public static void uncheck(Runnable_WithExceptions t) {
-        LambdaExceptionUtils.uncheck(t::run);
+        try {
+            t.run();
+        } catch (Exception exception) {
+            throwAsUnchecked(exception);
+        }
     }
 
     /**
      * uncheck(() -> Class.forName("xxx"));
      */
     public static <R, E extends Exception> R uncheck(Supplier_WithExceptions<R, E> supplier) {
-        return LambdaExceptionUtils.uncheck(supplier::get);
+        try {
+            return supplier.get();
+        } catch (Exception exception) {
+            throwAsUnchecked(exception);
+            return null;
+        }
     }
 
     /**
      * uncheck(Class::forName, "xxx");
      */
     public static <T, R, E extends Exception> R uncheck(Function_WithExceptions<T, R, E> function, T t) {
-        return LambdaExceptionUtils.uncheck(function::apply, t);
+        try {
+            return function.apply(t);
+        } catch (Exception exception) {
+            throwAsUnchecked(exception);
+            return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void throwAsUnchecked(Exception exception) throws E {
+        throw (E) exception;
     }
 
     @FunctionalInterface
-    @Deprecated(forRemoval = true)
     public interface Consumer_WithExceptions<T, E extends Exception> {
         void accept(T t) throws E;
     }
 
     @FunctionalInterface
-    @Deprecated(forRemoval = true)
     public interface BiConsumer_WithExceptions<T, U, E extends Exception> {
         void accept(T t, U u) throws E;
     }
 
     @FunctionalInterface
-    @Deprecated(forRemoval = true)
     public interface Function_WithExceptions<T, R, E extends Exception> {
         R apply(T t) throws E;
     }
 
     @FunctionalInterface
-    @Deprecated(forRemoval = true)
     public interface Supplier_WithExceptions<T, E extends Exception> {
         T get() throws E;
     }
 
     @FunctionalInterface
-    @Deprecated(forRemoval = true)
     public interface Runnable_WithExceptions<E extends Exception> {
         void run() throws E;
     }


### PR DESCRIPTION
This renames Lam**db**aExceptionUtils to Lam**bd**aExceptionUtils. It retains a copy of the class with the typo that redirects all the methods to the renamed class.