### PR TITLE
Fix ModuleLayerHandler#getLayer NPE on missing layer

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ModuleLayerHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ModuleLayerHandler.java
@@ -84,7 +84,7 @@ public final class ModuleLayerHandler implements IModuleLayerManager {
 
     @Override
     public Optional<ModuleLayer> getLayer(final Layer layer) {
-        return Optional.ofNullable(completedLayers.get(layer).layer());
+        return Optional.ofNullable(completedLayers.get(layer)).map(LayerInfo::layer);
     }
 
     public void updateLayer(Layer layer, Consumer<LayerInfo> action) {


### PR DESCRIPTION
As explained in #104, `ModuleLayerManager#getLayer` throws a NPE if the target layer hasn't been built yet, instead of returning an empty optional. This effectively voids the optional since its value must always be present.
To fix the issue, we replace dereferencing the nullable result of `completedLayers.get` with `Optional#map`.