### PR TITLE
Prevent transformers from running on empty bytes

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
@@ -47,6 +47,7 @@ public class TransformingClassLoader extends ModuleClassLoader {
 
     @Override
     protected byte[] maybeTransformClassBytes(final byte[] bytes, final String name, final String context) {
+        if (bytes.length == 0) return bytes;
         return classTransformer.transform(bytes, name, context != null ? context : ITransformerActivity.CLASSLOADING_REASON);
     }
 


### PR DESCRIPTION
As proposed earlier in [SecureJarHandler#28](https://github.com/McModLauncher/securejarhandler/pull/28):
> Proposal for changes:
    1. Prevent transforms from running on an empty byte array (this is also happening)

This PR adds a check to [TransformingClassLoader#maybeTransformClassBytes](https://github.com/Su5eD/modlauncher/blob/380683567c4ece1dffc2e43bf52aeb5eb2271bdb/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java#L50) to prevent transformers from running on an empty byte array. Instead, the input bytes are returned immediately.
