### PR TITLE
Let transformation services provide additional packages to modules

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/api/ITransformationService.java
+++ b/src/main/java/cpw/mods/modlauncher/api/ITransformationService.java
@@ -19,13 +19,18 @@
 package cpw.mods.modlauncher.api;
 
 import cpw.mods.jarhandling.SecureJar;
-import joptsimple.*;
+import joptsimple.OptionSpec;
+import joptsimple.OptionSpecBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URL;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Users who wish to provide a mod service which plugs into this API
@@ -129,6 +134,18 @@ public interface ITransformationService {
      */
     default Map.Entry<Set<String>,Supplier<Function<String, Optional<URL>>>> additionalResourcesLocator() {
         return null;
+    }
+
+    /**
+     * Allow transformation services to provide additional packages when asked for.
+     *
+     * Rules:
+     * The Strings in value Sets must be valid package names.
+     *
+     * @return a map of module names to a set of package names that will be added to the module descriptor upon resolution
+     */
+    default Map<String, Set<String>> additionalPackages() {
+        return Map.of();
     }
 
     interface OptionResult {

--- a/src/test/java/cpw/mods/modlauncher/test/LauncherTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/LauncherTests.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class LauncherTests {
     @Test
     void testLauncher() throws Exception {
-        Launcher.main("--version", "1.0", "--launchTarget", "mockLaunch", "--test.mods", "A,B,C,cpw.mods.modlauncher.testjar.TestClass", "--accessToken", "SUPERSECRET!");
+        Launcher.main("--version", "1.0", "--launchTarget", "mockLaunch", "--test.mods", "A,B,C,cpw.mods.modlauncher.testjar.TestClass,cheese.Puffs", "--accessToken", "SUPERSECRET!");
         Launcher instance = Launcher.INSTANCE;
         final Map<String, TransformationServiceDecorator> services = Whitebox.getInternalState(Whitebox.getInternalState(instance, "transformationServicesHandler"), "serviceLookup");
         final List<ITransformationService> launcherServices = services.values().stream()
@@ -71,7 +71,7 @@ class LauncherTests {
 
         final MockTransformerService mockTransformerService = (MockTransformerService) launcherServices.get(0);
         assertAll("test launcher service is correctly configured",
-                () -> assertIterableEquals(Arrays.asList("A", "B", "C", "cpw.mods.modlauncher.testjar.TestClass"), Whitebox.getInternalState(mockTransformerService, "modList"), "modlist is configured"),
+                () -> assertIterableEquals(Arrays.asList("A", "B", "C", "cpw.mods.modlauncher.testjar.TestClass", "cheese.Puffs"), Whitebox.getInternalState(mockTransformerService, "modList"), "modlist is configured"),
                 () -> assertEquals("INITIALIZED", Whitebox.getInternalState(mockTransformerService, "state"), "Initialized was called")
         );
 
@@ -88,6 +88,10 @@ class LauncherTests {
                     .orElseThrow();
             final Stream<Field> untransformedFields = Stream.of(Class.forName(testJarsModule, "cpw.mods.modlauncher.testjar.TestClass").getDeclaredFields());
             assertTrue(untransformedFields.noneMatch(f -> f.getName().equals("testfield")), "Didn't find transformed field");
+            
+            final Class<?> generatedClass = Class.forName("cheese.Puffs", true, Whitebox.getInternalState(Launcher.INSTANCE, "classLoader"));
+            assertEquals("cheese.Puffs", generatedClass.getName());
+            assertTrue(Stream.of(generatedClass.getDeclaredFields()).anyMatch(f -> f.getName().equals("testfield")), "Found generated field");
 
             Class<?> resClass = Class.forName("cpw.mods.modlauncher.testjar.ResourceLoadingClass", true, Whitebox.getInternalState(Launcher.INSTANCE, "classLoader"));
             assertFindResource(resClass);

--- a/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
+++ b/src/test/java/cpw/mods/modlauncher/test/MockTransformerService.java
@@ -83,6 +83,11 @@ public class MockTransformerService implements ITransformationService {
         return Stream.of(new ClassNodeTransformer(modList)).collect(Collectors.toList());
     }
 
+    @Override
+    public Map<String, Set<String>> additionalPackages() {
+        return Map.of("cpw.mods.modlauncher.testjars", Set.of("cheese"));
+    }
+
     static class ClassNodeTransformer implements ITransformer<ClassNode> {
         private final List<String> classNames;
 

--- a/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
+++ b/src/test/java/cpw/mods/modlauncher/test/TransformingClassLoaderTests.java
@@ -33,6 +33,7 @@ import java.lang.module.ModuleFinder;
 import java.lang.reflect.Constructor;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Test class loader
  */
 class TransformingClassLoaderTests {
-    private static final String TARGET_CLASS = "cpw.mods.modlauncher.testjar.TestClass";
+    private static final String TARGET_CLASS = "cheese.Puffs";
 
     @Test
     void testClassLoader() throws Exception {
@@ -65,7 +66,7 @@ class TransformingClassLoaderTests {
         new TypesafeMap(IEnvironment.class);
         Class<?> builderClass = Class.forName("cpw.mods.modlauncher.TransformingClassLoaderBuilder");
         Constructor<TransformingClassLoader> constructor = Whitebox.getConstructor(TransformingClassLoader.class, TransformStore.class, LaunchPluginHandler.class, builderClass, Environment.class, Configuration.class, List.class);
-        Configuration configuration = createTestJarsConfiguration();
+        Configuration configuration = createTestJarsConfiguration(mockTransformerService.additionalPackages());
         TransformingClassLoader tcl = constructor.newInstance(transformStore, lph, null, environment, configuration, List.of(ModuleLayer.boot()));
         ModuleLayer.boot().defineModules(configuration, s -> tcl);
         
@@ -77,9 +78,9 @@ class TransformingClassLoaderTests {
         assertEquals(aClass, newClass, "Class instance is the same from Class.forName and tcl.loadClass");
     }
     
-    private Configuration createTestJarsConfiguration() {
+    private Configuration createTestJarsConfiguration(Map<String, Set<String>> additionalPackages) {
         SecureJar testJars = SecureJar.from(Path.of(System.getProperty("testJars.location")));
-        JarModuleFinder finder = JarModuleFinder.of(testJars);
+        JarModuleFinder finder = JarModuleFinder.of(additionalPackages, testJars);
         return ModuleLayer.boot().configuration().resolveAndBind(finder, ModuleFinder.ofSystem(), Set.of("cpw.mods.modlauncher.testjars"));
     }
 }


### PR DESCRIPTION
## The Issue
Modules require defining their contained packages upon creation, which prevents us from generating classes in packages which do not already exist in the module.
Full issue here:
- https://github.com/McModLauncher/modlauncher/issues/90

## The Solution
Simply passing in the packages to the `TransformingClassLoader` would not be enough, as loading a class in a package which isn't part of the module will place it in the unnamed module instead.

To solve this, we have to provide additional packages to modules at the time of computing their descriptor.
This PR adds a new `Map<String, Set<String>> additionalPackages()` method to `ITransformationService`, which returns a map of module names to sets of package names. When the transformable layer is built, we [collect and merge all additional packages](https://github.com/Su5eD/modlauncher/blob/ffb63679d0d51b7d1ed366272157dd9afc979b0e/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java#L61) from transformation services, remove any duplicates, and pass them into SJH's `JarModuleFinder`, where they're added to their respective modules.

### Alternatives

Instead of using predefined `Set<String>` values in the `additionalPackages` map, we could use a `Supplier<Set<String>>` for the purpose of lazy evaluation. This depends on the consumer's needs, but a `Supplier` can be used for both eager and lazy evaluation in case we want to cover multiple use cases.

### Dependency PR in SecureJarHandler:
- https://github.com/McModLauncher/securejarhandler/pull/31