### PR TITLE
Remove OpenJ9 hard crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(16)
+    toolchain.languageVersion = JavaLanguageVersion.of(17)
     withSourcesJar()
 }
 
@@ -23,8 +23,6 @@ dependencyUpdates {
         isNonStable(it.candidate.version)
     }
 }
-
-ext.asmVersion = 9.3
 
 group = 'cpw.mods'
 version = gradleutils.getTagOffsetVersion()
@@ -112,7 +110,6 @@ task jmh(type: JavaExec, dependsOn: jmhClasses) {
     def results = file("${project.reportsDir}/jmh/result.json")
     doFirst {
         results.parentFile.mkdirs()
-
         jvmArgs(
                 '--module-path', sourceSets.jmh.runtimeClasspath.asPath,
                 '--add-modules', 'ALL-MODULE-PATH',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+#org.gradle.java.home=/home/cpw/minecraft/runtime/java-runtime-gamma/linux/java-runtime-gamma
+
+asmVersion=9.5

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -66,15 +66,16 @@ public class Launcher {
     }
 
     public static void main(String... args) {
-        if (System.getProperty("java.vm.name").contains("OpenJ9")) {
+        var props = System.getProperties();
+        if (props.getProperty("java.vm.name").contains("OpenJ9")) {
             System.err.printf("""
-            You are attempting to run with an unsupported Java Virtual Machine : %s
-            Please visit https://adoptopenjdk.net and install the HotSpot variant.
-            OpenJ9 is incompatible with several of the transformation behaviours that we rely on to work.
-            """, System.getProperty("java.vm.name"));
-            throw new IllegalStateException("Open J9 is not supported");
+            WARNING: OpenJ9 is detected. This is definitely unsupported and you may encounter issues and significantly worse performance.
+            For support and performance reasons, we recommend installing a temurin JVM from https://adoptium.net/
+            JVM information: %s %s %s
+            """, props.getProperty("java.vm.vendor"), props.getProperty("java.vm.name"), props.getProperty("java.vm.version"));
         }
         LogManager.getLogger().info(MODLAUNCHER,"ModLauncher running: args {}", () -> LaunchServiceHandler.hideAccessToken(args));
+        LogManager.getLogger().info(MODLAUNCHER, "JVM identified as {} {} {}", props.getProperty("java.vm.vendor"), props.getProperty("java.vm.name"), props.getProperty("java.vm.version"));
         new Launcher().run(args);
     }
 


### PR DESCRIPTION
Recent changes to openj9 mean it's not fundamentally incompatible anymore. We just log a warning because who knows how borked it'll end up being in real use, but hey, whatever. Some people think this is the best thing since sliced bread and a complete miracle worker.