### PR TITLE
Add action to test and publish the jmh results on different JVMs

### DIFF
--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -15,7 +15,7 @@ final dummyClassResults = [:]
 final noopResults = [:]
 
 final resultsPath = Path.of('jmh_results')
-Files.list(resultsPath).map { it.resolve('results.json') }
+Files.list(resultsPath).map { it.resolve('result.json') }
     .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
     .forEach {
         dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -15,8 +15,8 @@ final dummyClassResults = [:]
 final noopResults = [:]
 
 final resultsPath = Path.of('jmh_results')
-Files.list(resultsPath).map { it.resolve('result.json') }
-    .map { [new JsonSlurper().parse(Files.readString(it)), it.parent.fileName.toString().substring('jmh_'.length())] }
+Files.list(resultsPath).map { it.resolve('results.json') }
+    .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
     .forEach {
         dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
         noopResults[it[1]] = "${it[1][0].primaryMetric.score.round(2)} ± ${it[1][0].primaryMetric.scoreError.round(2)} ${it[1][0].primaryMetric.scoreUnit}"

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -32,7 +32,7 @@ Table.Builder noopTable = new Table.Builder()
         .addRow('JDK name & Version', 'Benchmark results')
 noopResults.forEach { type, results -> noopTable.addRow(type, results) }
 
-new File('jmh_results/final.md').text = """
+new File('jmh_results.md').text = """
 # `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
 ${dummyClassTable.build()}
 

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -1,0 +1,42 @@
+import groovy.json.JsonSlurper
+import net.steppschuh.markdowngenerator.table.Table
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+@GrabResolver(name = 'bintray', root='https://dl.bintray.com/steppschuh/Markdown-Generator/')
+@GrabResolver(name = 'central', root='https://repo1.maven.org/maven2/')
+@Grapes([
+    @Grab('org.apache.groovy:groovy-json:4.0.13'),
+    @Grab('net.steppschuh.markdowngenerator:markdowngenerator:1.3.2')
+])
+
+final dummyClassResults = [:]
+final noopResults = [:]
+
+final resultsPath = Path.of('jmh_results')
+Files.list(resultsPath).map { it.resolve('results.json') }
+    .map { [new JsonSlurper().parse(Files.readString(it)), it.parent.fileName.toString().substring('jmh_'.length())] }
+    .forEach {
+        dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
+        noopResults[it[1]] = "${it[1][0].primaryMetric.score.round(2)} ± ${it[1][0].primaryMetric.scoreError.round(2)} ${it[1][0].primaryMetric.scoreUnit}"
+    }
+
+Table.Builder dummyClassTable = new Table.Builder()
+        .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
+        .addRow('JDK name & Version', 'Benchmark results')
+dummyClassResults.forEach { type, results -> dummyClassTable.addRow(type, results) }
+
+Table.Builder noopTable = new Table.Builder()
+        .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
+        .addRow('JDK name & Version', 'Benchmark results')
+noopResults.forEach { type, results -> noopTable.addRow(type, results) }
+
+new File('jmh_results.md').text = """
+# Jmh Results
+## `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
+${dummyClassTable.build()}
+
+## `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformNoop` results
+${noopTable.build()}
+"""

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -4,11 +4,11 @@ import net.steppschuh.markdowngenerator.table.Table
 import java.nio.file.Files
 import java.nio.file.Path
 
-@GrabResolver(name = 'bintray', root='https://dl.bintray.com/steppschuh/Markdown-Generator/')
+@GrabResolver(name='jitpack.io', root='https://jitpack.io/')
 @GrabResolver(name = 'central', root='https://repo1.maven.org/maven2/')
 @Grapes([
     @Grab('org.apache.groovy:groovy-json:4.0.13'),
-    @Grab('net.steppschuh.markdowngenerator:markdowngenerator:1.3.2')
+    @Grab('com.github.Steppschuh:Java-Markdown-Generator:1.3.2')
 ])
 
 final dummyClassResults = [:]
@@ -32,11 +32,10 @@ Table.Builder noopTable = new Table.Builder()
         .addRow('JDK name & Version', 'Benchmark results')
 noopResults.forEach { type, results -> noopTable.addRow(type, results) }
 
-new File('jmh_results.md').text = """
-# Jmh Results
-## `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
+new File('jmh_results/final.md').text = """
+# `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
 ${dummyClassTable.build()}
 
-## `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformNoop` results
+# `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformNoop` results
 ${noopTable.build()}
 """

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -7,8 +7,8 @@ import java.nio.file.Path
 @GrabResolver(name='jitpack.io', root='https://jitpack.io/')
 @GrabResolver(name = 'central', root='https://repo1.maven.org/maven2/')
 @Grapes([
-    @Grab('org.apache.groovy:groovy-json:4.0.13'),
-    @Grab('com.github.Steppschuh:Java-Markdown-Generator:1.3.2')
+        @Grab('org.apache.groovy:groovy-json:4.0.13'),
+        @Grab('com.github.Steppschuh:Java-Markdown-Generator:1.3.2')
 ])
 
 final dummyClassResults = [:]
@@ -16,21 +16,21 @@ final noopResults = [:]
 
 final resultsPath = Path.of('jmh_results')
 Files.list(resultsPath).map { it.resolve('result.json') }
-    .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
-    .forEach {
-        dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
-        noopResults[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
-    }
+        .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
+        .forEach {
+            dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
+            noopResults[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
+        }
 
 Table.Builder dummyClassTable = new Table.Builder()
         .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
         .addRow('JDK name & Version', 'Benchmark results')
-dummyClassResults.forEach { type, results -> dummyClassTable.addRow(type, results) }
+dummyClassResults.sort { a, b -> a.value <=> b.value }.forEach { type, results -> dummyClassTable.addRow(type, results) }
 
 Table.Builder noopTable = new Table.Builder()
         .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
         .addRow('JDK name & Version', 'Benchmark results')
-noopResults.forEach { type, results -> noopTable.addRow(type, results) }
+noopResults.sort { a, b -> a.value <=> b.value }.forEach { type, results -> noopTable.addRow(type, results) }
 
 new File('jmh_results.md').text = """
 # `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -18,9 +18,10 @@ final resultsPath = Path.of('jmh_results')
 Files.list(resultsPath).map { it.resolve('result.json') }
         .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
         .forEach {
-            final osName = it[1].split('_')[1]
-            dummyClassResults.computeIfAbsent(osName, k -> [:])[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
-            noopResults.computeIfAbsent(osName, k -> [:])[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
+            final split = it[1].split('_', 2)
+            final osName = split[0]
+            dummyClassResults.computeIfAbsent(osName, k -> [:])[split[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
+            noopResults.computeIfAbsent(osName, k -> [:])[split[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
         }
 
 resultsText = '# Jmh Results'

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -15,7 +15,7 @@ final dummyClassResults = [:]
 final noopResults = [:]
 
 final resultsPath = Path.of('jmh_results')
-Files.list(resultsPath).map { it.resolve('results.json') }
+Files.list(resultsPath).map { it.resolve('result.json') }
     .map { [new JsonSlurper().parse(Files.readString(it)), it.parent.fileName.toString().substring('jmh_'.length())] }
     .forEach {
         dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -18,24 +18,31 @@ final resultsPath = Path.of('jmh_results')
 Files.list(resultsPath).map { it.resolve('result.json') }
         .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
         .forEach {
-            dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
-            noopResults[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
+            final osName = it[1].split('_')[1]
+            dummyClassResults.computeIfAbsent(osName, k -> [:])[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
+            noopResults.computeIfAbsent(osName, k -> [:])[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
         }
 
-Table.Builder dummyClassTable = new Table.Builder()
-        .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
-        .addRow('JDK name & Version', 'Benchmark results')
-dummyClassResults.sort { a, b -> a.value <=> b.value }.forEach { type, results -> dummyClassTable.addRow(type, results) }
+resultsText = '# Jmh Results'
+['Ubuntu': 'ubuntu-latest', 'MacOS': 'macos-latest', 'Windows': 'windows-latest'].each { osName, os ->
+    Table.Builder dummyClassTable = new Table.Builder()
+            .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
+            .addRow('JDK name & Version', 'Benchmark results')
+    (dummyClassResults[os] as Map).sort { a, b -> a.value <=> b.value }.forEach { type, results -> dummyClassTable.addRow(type, results) }
 
-Table.Builder noopTable = new Table.Builder()
-        .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
-        .addRow('JDK name & Version', 'Benchmark results')
-noopResults.sort { a, b -> a.value <=> b.value }.forEach { type, results -> noopTable.addRow(type, results) }
+    Table.Builder noopTable = new Table.Builder()
+            .withAlignments(Table.ALIGN_RIGHT, Table.ALIGN_RIGHT)
+            .addRow('JDK name & Version', 'Benchmark results')
+    (noopResults[os] as Map).sort { a, b -> a.value <=> b.value }.forEach { type, results -> noopTable.addRow(type, results) }
 
-new File('jmh_results.md').text = """
-# `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
+    resultsText += """
+\n## $osName
+### `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformDummyClass` results
 ${dummyClassTable.build()}
 
-# `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformNoop` results
+### `cpw.mods.modlauncher.benchmarks.TransformBenchmark.transformNoop` results
 ${noopTable.build()}
 """
+}
+
+new File('jmh_results.md').text = resultsText

--- a/.github/workflows/collect_jmh_results.groovy
+++ b/.github/workflows/collect_jmh_results.groovy
@@ -19,7 +19,7 @@ Files.list(resultsPath).map { it.resolve('result.json') }
     .map { [new JsonSlurper().parse(it.toFile()), it.parent.fileName.toString().substring('jmh_'.length())] }
     .forEach {
         dummyClassResults[it[1]] = "${it[0][0].primaryMetric.score.round(2)} ± ${it[0][0].primaryMetric.scoreError.round(2)} ${it[0][0].primaryMetric.scoreUnit}"
-        noopResults[it[1]] = "${it[1][0].primaryMetric.score.round(2)} ± ${it[1][0].primaryMetric.scoreError.round(2)} ${it[1][0].primaryMetric.scoreUnit}"
+        noopResults[it[1]] = "${it[0][1].primaryMetric.score.round(2)} ± ${it[0][1].primaryMetric.scoreError.round(2)} ${it[0][1].primaryMetric.scoreUnit}"
     }
 
 Table.Builder dummyClassTable = new Table.Builder()

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - jdk: Microsoft
             jvm_version: 17 # MS OpenJDK only has 11 and 17
-            os: [ ubuntu-latest, windows-latest, macos-latest ]
+            os: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
         #jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
-        jdk: []
+        jdk: [ Graal_VM ]
         exclude:
           - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -7,19 +7,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  testjvms:
-    name: Test JVM ${{ matrix.jvm }} version ${{ matrix.jvm_version }}
+  testjdks:
+    name: Test JDK ${{ matrix.jvm }} version ${{ matrix.jvm_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
+        #jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
+        jdk: []
         exclude:
-          - jvm: Graal_VM
+          - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version
         include:
-          - jvm: Microsoft
+          - jdk: Microsoft
             jvm_version: 17 # MS OpenJDK only has 11 and 177
     steps:
       - name: Checkout repository
@@ -33,12 +34,35 @@ jobs:
             caches
             notifications
             jdks
+          generate-job-summary: false
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Run Jmh with Gradle Wrapper
-        run: ./gradlew :jmh -PjmhVendor=${{ matrix.jvm }} -PjmhVersion=${{ matrix.jvm_version }}
+        run: ./gradlew :jmh -PjmhVendor=${{ matrix.jdk }} -PjmhVersion=${{ matrix.jvm_version }}
       - uses: actions/upload-artifact@v3
         name: Upload Results
         with:
-          name: jmh_${{ matrix.jvm }}-${{ matrix.jvm_version }}
+          name: jmh_${{ matrix.jdk }}-${{ matrix.jvm_version }}
           path: build/reports/jmh/result.json
+
+  upload_results:
+    name: Upload Jmh results
+    needs: [testjdks]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Setup Groovy
+        uses: wtfjoke/setup-groovy@v1
+        with:
+          groovy-version: '4.x'
+      - name: Checkout repository
+        uses: actions/checkout@main
+      - name: Downloads results
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          path: jmh_results
+      - name: Collect results
+        run: groovy .github/workflows/collect_jmh_results.groovy
+      - name: Upload Final Results
+        run: cat jmh_results.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK ]
+        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, Azul, IMB, Oracle ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   testjdks:

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Microsoft, Amazon, BellSoft, SAP ]
+        jvm: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
         exclude:
           - jvm: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -1,0 +1,33 @@
+name: Test JVMs and publish Jmh results
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  testjvms:
+    name: Test JVM ${{ matrix.jvm }} version ${{ matrix.jvm_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jvm_version: [ 17, 18, 19, 20 ]
+        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+      - name: Run Jmh with Gradle Wrapper
+        run: ./gradlew :jmh -PjmhVendor=${{ matrix.jvm }} -PjmhVersion=${{ matrix.jvm_version }}
+      - uses: actions/upload-artifact@v3
+        name: Upload Results
+        with:
+          name: jmh_${{ matrix.jvm }}-${{ matrix.jvm_version }}
+          path: build/reports/jmh/result.json

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -10,31 +10,25 @@ on:
 
 jobs:
   testjdks:
-    name: Test JDK ${{ matrix.jdk }} version ${{ matrix.jvm_version }} on OS ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Test JDK ${{ matrix.jdk }} version ${{ matrix.jvm_version }}
+    runs-on: ubuntu-latest
     strategy:
+      max-parallel: 10
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
         jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
         exclude:
           - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version
         include:
           - jdk: Microsoft
-            jvm_version: 17 # MS OpenJDK only has 11 and 17
-            os: ubuntu-latest
+            jvm_version: 17 # MS OpenJDK only has 11 and 177
     steps:
       - name: Checkout repository
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-      - name: Setup Temurin 17 for building
-        uses: actions/setup-java@v3
-        with:
-          distribution: temurin
-          java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -42,13 +36,12 @@ jobs:
           generate-job-summary: false
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-        if: ${{ matrix.os != 'windows-latest' }}
       - name: Run Jmh with Gradle Wrapper
         run: ./gradlew :jmh -PjmhVendor=${{ matrix.jdk }} -PjmhVersion=${{ matrix.jvm_version }}
       - uses: actions/upload-artifact@v3
         name: Upload Results
         with:
-          name: jmh_${{ matrix.os }}_${{ matrix.jdk }}-${{ matrix.jvm_version }}
+          name: jmh_${{ matrix.jdk }}-${{ matrix.jvm_version }}
           path: build/reports/jmh/result.json
 
   upload_results:

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -30,6 +30,11 @@ jobs:
         uses: actions/checkout@main
         with:
           fetch-depth: 0
+      - name: Setup Temurin 17 for building
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -17,13 +17,14 @@ jobs:
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
         jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
-        os: [ ubuntu-latest, windows-latest, macos-latesst ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         exclude:
           - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version
         include:
           - jdk: Microsoft
-            jvm_version: 17 # MS OpenJDK only has 11 and 177
+            jvm_version: 17 # MS OpenJDK only has 11 and 17
+            os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,8 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        #jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
-        jdk: [ Graal_VM ]
+        jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
         exclude:
           - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, Azul, IMB, Oracle ]
+        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, Azul, IBM, Oracle ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
         jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, AdoptOpenJDK-J9, Azul, IBM, Oracle, Microsoft, Amazon  ]
-    exclude:
-      - jvm: Graal_VM
-        jvm_version: 18 # Graal doesn't have a dedicated J18 version
+        exclude:
+          - jvm: Graal_VM
+            jvm_version: 18 # Graal doesn't have a dedicated J18 version
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -10,13 +10,14 @@ on:
 
 jobs:
   testjdks:
-    name: Test JDK ${{ matrix.jdk }} version ${{ matrix.jvm_version }}
-    runs-on: ubuntu-latest
+    name: Test JDK ${{ matrix.jdk }} version ${{ matrix.jvm_version }} on OS ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
         jdk: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Amazon, BellSoft, SAP ]
+        os: [ ubuntu-latest, windows-latest, macos-latesst ]
         exclude:
           - jdk: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version
@@ -38,12 +39,13 @@ jobs:
           generate-job-summary: false
       - name: Make gradlew executable
         run: chmod +x ./gradlew
+        if: ${{ matrix.os != 'windows-latest' }}
       - name: Run Jmh with Gradle Wrapper
         run: ./gradlew :jmh -PjmhVendor=${{ matrix.jdk }} -PjmhVersion=${{ matrix.jvm_version }}
       - uses: actions/upload-artifact@v3
         name: Upload Results
         with:
-          name: jmh_${{ matrix.jdk }}-${{ matrix.jvm_version }}
+          name: jmh_${{ matrix.os }}_${{ matrix.jdk }}-${{ matrix.jvm_version }}
           path: build/reports/jmh/result.json
 
   upload_results:

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,10 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, AdoptOpenJDK-J9, Azul, IBM, Oracle, Microsoft, Amazon  ]
+        jvm: [ Graal_VM, Adoptium, Azul, IBM, Oracle, Microsoft, Amazon, BellSoft, SAP ]
         exclude:
           - jvm: Graal_VM
             jvm_version: 18 # Graal doesn't have a dedicated J18 version
+        include:
+          - jvm: Microsoft
+            jvm_version: 17 # MS OpenJDK only has 11 and 177
     steps:
       - name: Checkout repository
         uses: actions/checkout@main
@@ -25,6 +28,10 @@ jobs:
           fetch-depth: 0
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        gradle-home-cache-includes: |
+          caches
+          notifications
+          jdks
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Run Jmh with Gradle Wrapper

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -28,10 +28,11 @@ jobs:
           fetch-depth: 0
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-        gradle-home-cache-includes: |
-          caches
-          notifications
-          jdks
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - name: Run Jmh with Gradle Wrapper

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -14,7 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         jvm_version: [ 17, 18, 19, 20 ]
-        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, Azul, IBM, Oracle ]
+        jvm: [ Graal_VM, Adoptium, AdoptOpenJDK, AdoptOpenJDK-J9, Azul, IBM, Oracle, Microsoft, Amazon  ]
+    exclude:
+      - jvm: Graal_VM
+        jvm_version: 18 # Graal doesn't have a dedicated J18 version
     steps:
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -38,10 +38,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-home-cache-includes: |
-            caches
-            notifications
-            jdks
+          cache-disabled: true
           generate-job-summary: false
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/test_jvms.yml
+++ b/.github/workflows/test_jvms.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testjdks:
-    name: Test JDK ${{ matrix.jvm }} version ${{ matrix.jvm_version }}
+    name: Test JDK ${{ matrix.jdk }} version ${{ matrix.jvm_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/build.gradle
+++ b/build.gradle
@@ -137,9 +137,12 @@ tasks.register('jmh', JavaExec) {
     ]
 
     if (project.hasProperty('jmhVendor') && project.hasProperty('jmhVersion')) {
+        final specifiedVendor = project.property('jmhVendor').toString()
+        final actualVendor = specifiedVendor.endsWith('-J9') ? specifiedVendor.substring(0, specifiedVendor.length() - 3) : specifiedVendor
         javaLauncher.set(javaToolchains.launcherFor {
-            it.vendor.set(JvmVendorSpec."${project.property('jmhVendor').toString().toUpperCase(Locale.ROOT)}" as JvmVendorSpec)
+            it.vendor.set(JvmVendorSpec."${actualVendor.toUpperCase(Locale.ROOT)}" as JvmVendorSpec)
             it.languageVersion.set(JavaLanguageVersion.of(project.property('jmhVersion') as int))
+            it.implementation.set(specifiedVendor.endsWith('-J9') ? JvmImplementation.J9 : JvmImplementation.VENDOR_SPECIFIC)
         })
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,12 +104,14 @@ test {
     )
 }
 
-task jmh(type: JavaExec, dependsOn: jmhClasses) {
+tasks.register('jmh', JavaExec) {
+    dependsOn('jmhClasses')
     mainClass = 'org.openjdk.jmh.Main'
 
-    def results = file("${project.reportsDir}/jmh/result.json")
+    final results = file("${project.reportsDir}/jmh/result.json")
     doFirst {
         results.parentFile.mkdirs()
+
         jvmArgs(
                 '--module-path', sourceSets.jmh.runtimeClasspath.asPath,
                 '--add-modules', 'ALL-MODULE-PATH',
@@ -133,6 +135,13 @@ task jmh(type: JavaExec, dependsOn: jmhClasses) {
             '-rf', 'json',
             '-rff', results
     ]
+
+    if (project.hasProperty('jmhVendor') && project.hasProperty('jmhVersion')) {
+        javaLauncher.set(javaToolchains.launcherFor {
+            it.vendor.set(JvmVendorSpec."${project.property('jmhVendor').toString().toUpperCase(Locale.ROOT)}" as JvmVendorSpec)
+            it.languageVersion.set(JavaLanguageVersion.of(project.property('jmhVersion') as int))
+        })
+    }
 }
 
 ext.sharedManifest = manifest {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.4.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.6.0'
 }
 
 


### PR DESCRIPTION
This PR adds a GitHub action that will run the `jmh` task on different combinations of JDKs and Java versions using an action matrix. The results will be collected and display in a job summary.