### PR TITLE
Modify class reader flags in class transformer

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -73,7 +73,7 @@ public class ClassTransformer {
         boolean empty;
         if (inputClass.length > 0) {
             final ClassReader classReader = new ClassReader(inputClass);
-            classReader.accept(clazz, 0);
+            classReader.accept(clazz, ClassReader.EXPAND_FRAMES);
             digest = ()->getSha256().digest(inputClass);
             empty = false;
         } else {


### PR DESCRIPTION
Changes the flags used to read `ClassNode`s in `ClassTransformer` from `0` to `ClassReader.EXPAND_FRAMES`. This ensures the correctness of local variable analysis, while also achieving parity with Fabric's flag usage (which is currently the inverse of modlauncher's settings).

https://github.com/McModLauncher/modlauncher/blob/26f72269378e5e181e184191ad89fd1702c33bae/src/main/java/cpw/mods/modlauncher/ClassTransformer.java#L76

For a complete description of the issue, please see neoforged/NeoForge#768