### PR TITLE
Make TransformingClassLoader usable in FML tests.

### DIFF
--- a/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
@@ -26,6 +26,7 @@ import cpw.mods.modlauncher.util.ServiceLoaderUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
@@ -33,6 +34,7 @@ import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static cpw.mods.modlauncher.LogMarkers.*;
 
@@ -41,10 +43,14 @@ public class LaunchPluginHandler {
     private final Map<String, ILaunchPluginService> plugins;
 
     public LaunchPluginHandler(final ModuleLayerHandler layerHandler) {
-        this.plugins = ServiceLoaderUtils.streamServiceLoader(()->ServiceLoader.load(layerHandler.getLayer(IModuleLayerManager.Layer.BOOT).orElseThrow(), ILaunchPluginService.class),
-                e->LOGGER.fatal(MODLAUNCHER, "Encountered serious error loading launch plugin service. Things will not work well", e))
-                .collect(Collectors.toMap(ILaunchPluginService::name, Function.identity()));
-        final var modlist = plugins.entrySet().stream().map(e->Map.of(
+        this(ServiceLoaderUtils.streamServiceLoader(()->ServiceLoader.load(layerHandler.getLayer(IModuleLayerManager.Layer.BOOT).orElseThrow(), ILaunchPluginService.class),
+                e->LOGGER.fatal(MODLAUNCHER, "Encountered serious error loading launch plugin service. Things will not work well", e)));
+    }
+
+    @VisibleForTesting
+    public LaunchPluginHandler(Stream<ILaunchPluginService> plugins) {
+        this.plugins = plugins.collect(Collectors.toMap(ILaunchPluginService::name, Function.identity()));
+        final var modlist = this.plugins.entrySet().stream().map(e->Map.of(
                 "name", e.getKey(),
                 "type", "PLUGINSERVICE",
                 "file", ServiceLoaderUtils.fileNameFor(e.getValue().getClass())))
@@ -55,7 +61,7 @@ public class LaunchPluginHandler {
                         throw new RuntimeException("The MODLIST isn't set, huh?");
                     });
         }
-        LOGGER.debug(MODLAUNCHER,"Found launch plugins: [{}]", ()-> String.join(",", plugins.keySet()));
+        LOGGER.debug(MODLAUNCHER,"Found launch plugins: [{}]", ()-> String.join(",", this.plugins.keySet()));
     }
 
     public Optional<ILaunchPluginService> get(final String name) {

--- a/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServiceDecorator.java
@@ -21,6 +21,7 @@ package cpw.mods.modlauncher;
 import cpw.mods.modlauncher.api.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.*;
 import java.util.stream.*;
@@ -35,7 +36,8 @@ public class TransformationServiceDecorator {
     private final ITransformationService service;
     private boolean isValid;
 
-    TransformationServiceDecorator(ITransformationService service) {
+    @VisibleForTesting
+    public TransformationServiceDecorator(ITransformationService service) {
         this.service = service;
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
@@ -20,6 +20,7 @@ package cpw.mods.modlauncher;
 
 import cpw.mods.cl.ModuleClassLoader;
 import cpw.mods.modlauncher.api.*;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.lang.module.Configuration;
 import java.util.*;
@@ -33,13 +34,19 @@ public class TransformingClassLoader extends ModuleClassLoader {
     }
     private final ClassTransformer classTransformer;
 
-    public TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, ModuleLayerHandler moduleLayerHandler) {
+    public TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, IModuleLayerManager moduleLayerHandler) {
         super("TRANSFORMER", moduleLayerHandler.getLayer(IModuleLayerManager.Layer.GAME).orElseThrow().configuration(), List.of(moduleLayerHandler.getLayer(IModuleLayerManager.Layer.SERVICE).orElseThrow()));
         this.classTransformer = new ClassTransformer(transformStore, pluginHandler, this);
     }
 
-    TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, final Environment environment, final Configuration configuration, List<ModuleLayer> parentLayers) {
-        super("TRANSFORMER", configuration, parentLayers);
+    @VisibleForTesting
+    public TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, final Environment environment, final Configuration configuration, List<ModuleLayer> parentLayers) {
+        this(transformStore, pluginHandler, environment, configuration, parentLayers, null);
+    }
+
+    @VisibleForTesting
+    public TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, final Environment environment, final Configuration configuration, List<ModuleLayer> parentLayers, ClassLoader parentClassLoader) {
+        super("TRANSFORMER", configuration, parentLayers, parentClassLoader);
         TransformerAuditTrail tat = new TransformerAuditTrail();
         environment.computePropertyIfAbsent(IEnvironment.Keys.AUDITTRAIL.get(), v->tat);
         this.classTransformer = new ClassTransformer(transformStore, pluginHandler, this, tat);

--- a/src/main/java/cpw/mods/modlauncher/util/ServiceLoaderUtils.java
+++ b/src/main/java/cpw/mods/modlauncher/util/ServiceLoaderUtils.java
@@ -45,6 +45,11 @@ public final class ServiceLoaderUtils {
     }
 
     public static String fileNameFor(Class<?> clazz) {
+        // Used in test scenarios where services might come from normal CP
+        if (clazz.getModule().getLayer() == null) {
+            return clazz.getProtectionDomain().getCodeSource().getLocation().getFile();
+        }
+
         return clazz.getModule().getLayer().configuration()
                 .findModule(clazz.getModule().getName())
                 .flatMap(rm->rm.reference().location())


### PR DESCRIPTION
Used in https://github.com/neoforged/FancyModLoader/pull/163 to set up a relatively close-to-real loading process. Access to the transforming classloader is needed to test coremods and enum extensions.

I tried to only make constructors available, which means this does not actually add the ability to access more state at runtime for mods or such.