### PR TITLE
Remove package scanning in log4j2 configuration

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn" packages="cpw.mods.modlauncher.log">
+<Configuration status="warn">
     <filters>
         <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="CLASSLOADING" onMatch="DENY" onMismatch="NEUTRAL"/>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="warn" packages="cpw.mods.modlauncher.log">
+<Configuration status="warn">
     <filters>
         <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="CLASSLOADING" onMatch="DENY" onMismatch="NEUTRAL"/>


### PR DESCRIPTION
ModLauncher already includes the annotation processor that now writes the plugin metadata, making the deprecated packages attribute obsolete.

This fixes warnings we get on startup:
WARN StatusConsoleListener The use of package scanning to locate plugins is deprecated and will be removed in a future release